### PR TITLE
BUG with ray 1.0.0

### DIFF
--- a/ray-crash-course/pi_calc.py
+++ b/ray-crash-course/pi_calc.py
@@ -104,7 +104,7 @@ def compute_pi_loop(N):
 
 @ray.remote
 class RayMonteCarloPi(MonteCarloPi):
-    @ray.method(num_return_vals=5)
+    @ray.method(num_returns=5)  
     def sample(self, num_samples):
         return super().sample(num_samples)
 


### PR DESCRIPTION
This is intended as an issue more than a PR. 
The changed line raises an assertion error, because the keyword seems to be wrong. 
I used ray 1.0.0 on my local computer. 
I assume this is a version issue.
There might be other places in the tutorial where this also happens, so this is just a heads up.